### PR TITLE
Remove 'type' field from package.json

### DIFF
--- a/src/commands/init/create/package.json.ts
+++ b/src/commands/init/create/package.json.ts
@@ -10,7 +10,6 @@ export const getPackageJson = (
     {
       name: `${name}`,
       version: "0.0.0",
-      type: "module",
       scripts: {
         build: "godot-ts build",
         dev: "npm-run-all build generate -p watch watch-generate open-editor",


### PR DESCRIPTION
Removed the 'type' field from the package.json structure. GodotJS projects are not modules. `"type": "module"` in `package.json` causes tsc emit to behave differently.

See https://github.com/godotjs/GodotJS/issues/202